### PR TITLE
pose_follower: Fixes false "goal reached" when blocked

### DIFF
--- a/pose_follower/src/pose_follower.cpp
+++ b/pose_follower/src/pose_follower.cpp
@@ -197,6 +197,8 @@ namespace pose_follower {
       ROS_ERROR("Not legal (%.2f, %.2f, %.2f)", limit_vel.linear.x, limit_vel.linear.y, limit_vel.angular.z);
       geometry_msgs::Twist empty_twist;
       cmd_vel = empty_twist;
+      // Tickle the timestamp so we don't erroneously report goal reached
+      goal_reached_time_ = ros::Time::now();
       return false;
     }
 


### PR DESCRIPTION
When blocked by an obstacle for several seconds, isGoalReached() was
erroneously returning true. The goal_reached_time_ needed to be updated to
signify that we have not yet reached the goal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation_experimental/4)
<!-- Reviewable:end -->
